### PR TITLE
Vasil remove remote evals

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@
 // Nodeload configuration
 // ------------------------------------
 //
-// The functions in this file control the behavior of the nodeload globals, like HTTP_SERVER and 
+// The functions in this file control the behavior of the nodeload globals, like HTTP_SERVER and
 // REPORT_MANAGER. They should be called when the library is included:
 //
 //      var nl = require('./lib/nodeload').quiet().usePort(10000);
@@ -76,9 +76,11 @@ var NODELOAD_CONFIG = exports.NODELOAD_CONFIG = {
     AJAX_REFRESH_INTERVAL_MS: 2000,
 
     LOGS_ENABLED: process.env.LOGS ? process.env.LOGS !== '0' : true,
-    
+
     SLAVE_UPDATE_INTERVAL_MS: 3000,
-    
+
+    SLAVE_SPECIFICATIONS: process.env.SLAVE_SPECIFICATIONS || null,
+
     eventEmitter: new EventEmitter(),
     on: function(event, fun) {
         this.eventEmitter.on(event, fun);

--- a/lib/remote/defaultslavespec.js
+++ b/lib/remote/defaultslavespec.js
@@ -1,0 +1,47 @@
+var BUILD_AS_SINGLE_FILE;
+if (!BUILD_AS_SINGLE_FILE) {
+var util = require('../util');
+var qputs = util.qputs;
+}
+
+exports.setup = function() {
+    if (typeof BUILD_AS_SINGLE_FILE === 'undefined' || BUILD_AS_SINGLE_FILE === false) {
+        this.nlrun = require('../loadtesting').run;
+    } else {
+        this.nlrun = run;
+    }
+}
+
+exports.runTests = function(master, specsStr) {
+    var specs;
+    try {
+        // TODO: use command line option to provide path file/directory
+        // containing the code, instead of doing eval.
+        eval('specs='+specsStr);
+    } catch(e) {
+        qputs('WARN: Ignoring invalid remote test specifications: ' + specsStr + ' - ' + e.toString());
+        return;
+    }
+
+    if (this.state === 'running') {
+        qputs('WARN: Already running -- ignoring new test specifications: ' + specsStr);
+        return;
+    }
+
+    qputs('Received remote test specifications: ' + specsStr);
+
+    var self = this;
+    self.state = 'running';
+    self.loadtest = self.nlrun(specs);
+    self.loadtest.keepAlive = true;
+    self.loadtest.on('update', function(interval, stats) {
+        master.sendStats(interval);
+    });
+    self.loadtest.on('end', function() {
+        self.state = 'done';
+    });
+}
+
+exports.stopTests = function(master) {
+    if (this.loadtest) { this.loadtest.stop(); }
+}

--- a/lib/remote/defaultslavespec.js
+++ b/lib/remote/defaultslavespec.js
@@ -2,6 +2,7 @@ var BUILD_AS_SINGLE_FILE;
 if (!BUILD_AS_SINGLE_FILE) {
 var util = require('../util');
 var qputs = util.qputs;
+var NODELOAD_CONFIG = require('../config').NODELOAD_CONFIG;
 }
 
 exports.setup = function() {
@@ -15,9 +16,15 @@ exports.setup = function() {
 exports.runTests = function(master, specsStr) {
     var specs;
     try {
-        // TODO: use command line option to provide path file/directory
-        // containing the code, instead of doing eval.
-        eval('specs='+specsStr);
+        var specMap = {};
+        if (NODELOAD_CONFIG.SLAVE_SPECIFICATIONS) {
+            specMap = util.loadSpecsFile(
+                NODELOAD_CONFIG.SLAVE_SPECIFICATIONS);
+        }
+        // TODO: add support for multiple specs
+        var overrideSpec = JSON.parse(specsStr)[0];
+        var baseSpec = specMap[overrideSpec.spec];
+        specs = util.constructSlaveSpec(baseSpec, overrideSpec);
     } catch(e) {
         qputs('WARN: Ignoring invalid remote test specifications: ' + specsStr + ' - ' + e.toString());
         return;

--- a/lib/remote/endpointclient.js
+++ b/lib/remote/endpointclient.js
@@ -30,8 +30,6 @@ var EndpointClient = exports.EndpointClient = function EndpointClient(host, port
     EventEmitter.call(this);
     this.host = host;
     this.port = port;
-    this.client = util.createReconnectingClient(port, host);
-    this.client.on('error', this.emit.bind(this, 'error'));
     this.basepath = basepath || '';
     this.methodNames = [];
     this.retryInterval = DEFAULT_RETRY_INTERVAL_MS;
@@ -40,7 +38,14 @@ var EndpointClient = exports.EndpointClient = function EndpointClient(host, port
 util.inherits(EndpointClient, EventEmitter);
 /** Send an arbitrary HTTP request using the underlying http.Client. */
 EndpointClient.prototype.rawRequest = function() {
-    return this.client.request.apply(this.client, arguments);
+    // NOTE: It seems we dont need reconnect functionality here,
+    // so we can safely use http.request instead of util.createReconnectingClient.
+    // TODO: Should reconnect functionality turn out to be needed, additional
+    // reqest logic should be added in the on('error') handler, to support the case.
+    var options = util.wrapOldRequestArguments(this.port, this.host, arguments);
+    var req = http.request(options);
+    req.on('error', this.emit.bind(this, 'error'));
+    return req;
 };
 EndpointClient.prototype.setStaticParams = function(params) {
     this.staticParams_ = params instanceof Array ? params : [params];
@@ -50,7 +55,7 @@ endpointClient.method(args...). */
 EndpointClient.prototype.defineMethod = function(name) {
     var self = this;
     self[name] = function() {
-        var req = self.client.request('POST', self.basepath + '/' + name),
+        var req = self.rawRequest('POST', self.basepath + '/' + name),
             params = self.staticParams_.concat(util.argarray(arguments));
 
         req.on('response', function(res) {

--- a/lib/remote/remotetesting.js
+++ b/lib/remote/remotetesting.js
@@ -163,9 +163,8 @@ LoadTestCluster.prototype.startTests_ = function() {
     this.reports = {};
     this.interval = {};
     this.stats = {};
-    // TODO: pass the specs in a different way. See the comment
-    // in defaultslavespec.js.
-    this.cluster.runTests(this.stringify_(this.specs));
+    // stringify ignores function fields
+    this.cluster.runTests(JSON.stringify(this.specs));
 
     Object.defineProperty(this.stats, 'summary', {
         enumerable: false,

--- a/lib/remote/remotetesting.js
+++ b/lib/remote/remotetesting.js
@@ -29,6 +29,7 @@ var stats = require('../stats');
 var reporting = require('../reporting');
 var run = require('../loadtesting').run;
 var Cluster = require('./cluster').Cluster;
+var DefaultSlaveSpec = require('./defaultslavespec')
 var EventEmitter = require('events').EventEmitter;
 var StatsLogger = require('../monitoring/statslogger').StatsLogger;
 var Report = reporting.Report;
@@ -162,6 +163,8 @@ LoadTestCluster.prototype.startTests_ = function() {
     this.reports = {};
     this.interval = {};
     this.stats = {};
+    // TODO: pass the specs in a different way. See the comment
+    // in defaultslavespec.js.
     this.cluster.runTests(this.stringify_(this.specs));
 
     Object.defineProperty(this.stats, 'summary', {
@@ -224,46 +227,7 @@ LoadTestCluster.prototype.getClusterSpec_ = function() {
                 });
             }
         },
-        slaves: {
-            hosts: self.slaveHosts,
-            setup: function() {
-                if (typeof BUILD_AS_SINGLE_FILE === 'undefined' || BUILD_AS_SINGLE_FILE === false) {
-                    this.nlrun = require('../loadtesting').run;
-                } else {
-                    this.nlrun = run;
-                }
-            },
-            runTests: function(master, specsStr) {
-                var specs;
-                try {
-                    eval('specs='+specsStr);
-                } catch(e) {
-                    qputs('WARN: Ignoring invalid remote test specifications: ' + specsStr + ' - ' + e.toString());
-                    return;
-                }
-
-                if (this.state === 'running') {
-                    qputs('WARN: Already running -- ignoring new test specifications: ' + specsStr);
-                    return;
-                }
-
-                qputs('Received remote test specifications: ' + specsStr);
-
-                var self = this;
-                self.state = 'running';
-                self.loadtest = self.nlrun(specs);
-                self.loadtest.keepAlive = true;
-                self.loadtest.on('update', function(interval, stats) {
-                    master.sendStats(interval);
-                });
-                self.loadtest.on('end', function() {
-                    self.state = 'done';
-                });
-            },
-            stopTests: function(master) {
-                if (this.loadtest) { this.loadtest.stop(); }
-            }
-        },
+        slaves: util.extend(DefaultSlaveSpec, {hosts: self.slaveHosts}),
         server: self.masterHttpServer,
         pingInterval: self.slaveUpdateInterval
     };

--- a/lib/remote/slave.js
+++ b/lib/remote/slave.js
@@ -39,7 +39,8 @@ var Slave = exports.Slave = function Slave(id, host, port, masterEndpoint, pingI
     this.client.on('error', this.emit.bind(this, 'slaveError'));
     this.masterEndpoint = masterEndpoint;
     this.pingInterval = pingInterval || NODELOAD_CONFIG.SLAVE_UPDATE_INTERVAL_MS;
-    this.methodDefs = [];
+    // TODO: remove this
+    //this.methodDefs = [];
     this.state = 'initialized';
 };
 util.inherits(Slave, EventEmitter);
@@ -58,7 +59,8 @@ Slave.prototype.start = function() {
         id: self.id,
         master: masterUrl,
         masterMethods: masterMethods,
-        slaveMethods: self.methodDefs,
+        // TODO: remove this
+        //slaveMethods: self.methodDefs,
         pingInterval: self.pingInterval
     }));
     req.on('response', function(res) {
@@ -99,5 +101,6 @@ Slave.prototype.defineMethod = function(name, fun) {
     var self = this;
     self.client.defineMethod(name, fun);
     self[name] = function() { return self.client[name].apply(self.client, arguments); };
-    self.methodDefs.push({name: name, fun: fun.toString()});
+    // TODO: remove this
+    //self.methodDefs.push({name: name, fun: fun.toString()});
 };

--- a/lib/remote/slave.js
+++ b/lib/remote/slave.js
@@ -39,8 +39,6 @@ var Slave = exports.Slave = function Slave(id, host, port, masterEndpoint, pingI
     this.client.on('error', this.emit.bind(this, 'slaveError'));
     this.masterEndpoint = masterEndpoint;
     this.pingInterval = pingInterval || NODELOAD_CONFIG.SLAVE_UPDATE_INTERVAL_MS;
-    // TODO: remove this
-    //this.methodDefs = [];
     this.state = 'initialized';
 };
 util.inherits(Slave, EventEmitter);
@@ -59,8 +57,6 @@ Slave.prototype.start = function() {
         id: self.id,
         master: masterUrl,
         masterMethods: masterMethods,
-        // TODO: remove this
-        //slaveMethods: self.methodDefs,
         pingInterval: self.pingInterval
     }));
     req.on('response', function(res) {
@@ -101,6 +97,4 @@ Slave.prototype.defineMethod = function(name, fun) {
     var self = this;
     self.client.defineMethod(name, fun);
     self[name] = function() { return self.client[name].apply(self.client, arguments); };
-    // TODO: remove this
-    //self.methodDefs.push({name: name, fun: fun.toString()});
 };

--- a/lib/remote/slavenode.js
+++ b/lib/remote/slavenode.js
@@ -3,6 +3,7 @@ if (!BUILD_AS_SINGLE_FILE) {
 var url = require('url');
 var util = require('../util');
 var qputs = util.qputs;
+var DefaultSlaveSpec = require('./defaultslavespec')
 var Endpoint = require('./endpoint').Endpoint;
 var EndpointClient = require('./endpointclient').EndpointClient;
 var EventEmitter = require('events').EventEmitter;
@@ -39,7 +40,9 @@ var SlaveNode = exports.SlaveNode = function SlaveNode(server, spec) {
     var self = this, slaveState = 'initialized';
     this.id = spec.id;
     this.masterClient_ = spec.master ? this.createMasterClient_(spec.master, spec.masterMethods) : null;
-    this.slaveEndpoint_ = this.createEndpoint_(server, spec.slaveMethods);
+    // TODO: how can we specify another SlaveSpec?
+    // Use some command line option?
+    this.slaveEndpoint_ = this.createEndpoint_(server, DefaultSlaveSpec)
     this.slaveEndpoint_.setStaticParams([this.masterClient_]);
     this.slaveEndpoint_.on('start', function() { this.emit.bind(this, 'start'); });
     this.slaveEndpoint_.on('end', this.end.bind(this));
@@ -70,19 +73,12 @@ SlaveNode.prototype.createEndpoint_ = function(server, methods) {
     // Add a new endpoint and route to the HttpServer
     var endpoint = new Endpoint(server);
 
-    // "Compile" the methods by eval()'ing the string in "fun", and add to the endpoint
     if (methods) {
-        try {
-            methods.forEach(function(m) {
-                var fun;
-                eval('fun=' + m.fun);
-                endpoint.defineMethod(m.name, fun);
-            });
-        } catch (e) {
-            endpoint.end();
-            endpoint = null;
-            throw e;
-        }
+        util.forEach(methods, function(method, val) {
+            if (typeof val === 'function') {
+                endpoint.defineMethod(method, val);
+            }
+        });
     }
 
     return endpoint;
@@ -117,6 +113,7 @@ var installRemoteHandler = exports.installRemoteHandler = function(server) {
                 // Grab the slave endpoint definition from the HTTP request body; should be valid JSON
                 try {
                     body = JSON.parse(body);
+                    console.log(body);
                     slaveNode = new SlaveNode(server, body);
                 } catch(e) {
                     res.writeHead(400);

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,6 +12,7 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var NODELOAD_CONFIG = require('./config').NODELOAD_CONFIG;
 }
+var _ = require('underscore');
 
 // A few common global functions so we can access them with as few keystrokes as possible
 //
@@ -173,5 +174,31 @@ util.LineReader = function(eventEmitter, event) {
   eventEmitter.on(event, readloop.bind(this));
 }
 util.inherits(util.LineReader, EventEmitter);
+
+util.loadSpecsFile = function(filename) {
+    try {
+        var moduleName = filename.substring(0, filename.lastIndexOf('.'));
+        var mod = require(moduleName);
+        return mod.getSpecsMap();
+    } catch (e) {
+        qputs('Could not load "' + filename + '" and call method getScenariosMap');
+        return {}
+    }
+}
+
+util.constructSlaveSpec = function(baseSlaveSpec, overrideSpec) {
+    var spec = _.clone(baseSlaveSpec);
+    // See the documentation lib/loop/loop for details.
+    // Basically, we strip all function parameters and leave the rest.
+    // Also allow stats parameter.
+    // TODO: allow more parameters if needed.
+    var filter = [
+        'name',
+        'args', 'rps', 'duration', 'numberOfTimes', 'concurrency',
+        'concurrencyProfile', 'rpsProfile',
+        'timeLimit', 'stats'];
+    var filteredSpec = _.pick(overrideSpec, filter);
+    return _.extend(spec, filteredSpec);
+}
 
 util.extend(exports, util);

--- a/lib/util.js
+++ b/lib/util.js
@@ -91,13 +91,33 @@ util.PeriodicUpdater = function(updateIntervalMs) {
     this.updateInterval = updateIntervalMs;
 };
 
+util.wrapOldRequestArguments = function(port, host, oldArguments) {
+    // NODE: It seems I can't find full documentation of the
+    // client.request method. From examining the nodeload library
+    // assume it is (method, path, headers). Investigate further.
+    var options = {
+        port: port,
+        host: host,
+    };
+    if (oldArguments.length > 0) {
+        options.method = oldArguments[0];
+    }
+    if (oldArguments.length > 1) {
+        options.path = oldArguments[1];
+    }
+    if (oldArguments.length > 2) {
+        options.headers = oldArguments[2];
+    }
+    return options;
+}
+
 /** Same arguments as http.createClient. Returns an wrapped http.Client object that will reconnect when
 connection errors are detected. In the current implementation of http.Client (11/29/10), calls to
 request() fail silently after the initial 'error' event. */
 util.createReconnectingClient = function() {
     var http = require('http'),
         clientArgs = arguments, events = {}, client, wrappedClient = {},
-        clientMethod = function(method) { 
+        clientMethod = function(method) {
             return function() { return client[method].apply(client, arguments); };
         },
         clientGetter = function(member) { return function() { return client[member]; };},
@@ -109,7 +129,7 @@ util.createReconnectingClient = function() {
             client._events = util.extend(events, client._events); // EventEmitter._events stores event handlers
             client.emit('reconnect', oldclient);
         };
-    
+
     // Create initial http.Client
     reconnect();
     client.on('error', function(err) { reconnect(); });
@@ -129,10 +149,10 @@ util.createReconnectingClient = function() {
 
 /** Accepts an EventEmitter object that emits text data. LineReader buffers the text and emits a 'data'
 event each time a newline is encountered. For example, */
-util.LineReader = function(eventEmitter, event) {  
+util.LineReader = function(eventEmitter, event) {
   EventEmitter.call(this);
   event = event || 'data';
-  
+
   var self = this, buffer = '';
 
   var emitLine = function(buffer) {
@@ -141,15 +161,15 @@ util.LineReader = function(eventEmitter, event) {
     if (line) { self.emit('data', line); }
     return buffer.substring(line.length + 1, buffer.length);
   };
-  
-  var readloop = function(data) { 
+
+  var readloop = function(data) {
     if (data) { buffer += data.toString(); }
-    if (buffer.indexOf("\n") > -1) {     
+    if (buffer.indexOf("\n") > -1) {
       buffer = emitLine(buffer);
       process.nextTick(readloop.bind(this));
     }
   };
-  
+
   eventEmitter.on(event, readloop.bind(this));
 }
 util.inherits(util.LineReader, EventEmitter);


### PR DESCRIPTION
@skaapgif It seems that last time I sent this pull request to the gamechanger/nodeload instead of edgecampus/nodeload. I am correcting myself on that one.

With this changes the library should be usable to us. The critical eval have been removed and we can specify test scenarios via environment variable, so that the slaves can see them.

I have also created a development branch in our forked repository so that we can keep any changes there. I don't want to merge them in master, since the changes will break interface compatibility with the original project.
